### PR TITLE
Fixes when Notification do not have loaId for update

### DIFF
--- a/zonkylla/core/zonky.py
+++ b/zonkylla/core/zonky.py
@@ -312,7 +312,7 @@ class Zonky:
 
         print('# Update transactions')
         transactions = self.get_transactions(from_dt=last_dt)
-        updated_loan_ids = [trans['loanId'] for trans in transactions]
+        updated_loan_ids = [trans['loanId'] for trans in transactions if trans['loanId']]
         database.insert_transactions(transactions)
 
         print('# Download missing loans')


### PR DESCRIPTION
Some transactions do not have loanId present such as that with DEPOSIT type.